### PR TITLE
Fix code scanning alert no. 286: File created without restricting permissions

### DIFF
--- a/swift/extractor/infra/file/TargetFile.cpp
+++ b/swift/extractor/infra/file/TargetFile.cpp
@@ -43,9 +43,10 @@ TargetFile::TargetFile(const std::filesystem::path& target,
 
 bool TargetFile::init() {
   errno = 0;
-  // since C++17 "x" mode opens with O_EXCL (fails if file already exists)
-  if (auto f = std::fopen(targetPath.c_str(), "wx")) {
-    std::fclose(f);
+  // open the file with restrictive permissions
+  int fd = open(targetPath.c_str(), O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+  if (fd != -1) {
+    close(fd);
     out.open(workingPath);
     checkOutput("open");
     return true;


### PR DESCRIPTION
Fixes [https://github.com/krishnprakash/codeql/security/code-scanning/286](https://github.com/krishnprakash/codeql/security/code-scanning/286)

To fix the problem, we need to ensure that the file is created with restrictive permissions, specifically allowing only the current user to read and write to the file. This can be achieved by using the `open` function with the appropriate flags and permissions instead of `std::fopen`. The `open` function allows us to specify the permissions explicitly.

We will replace the `std::fopen` call with an `open` call that includes the `O_WRONLY | O_CREAT | O_EXCL` flags and the `S_IRUSR | S_IWUSR` permissions. After opening the file, we can use `fdopen` to obtain a `FILE*` stream if needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
