### PR TITLE
Potential fix for code scanning alert no. 4: Missed opportunity to use Where

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Populators/TypeContainerVisitor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Populators/TypeContainerVisitor.cs
@@ -25,10 +25,10 @@ namespace Semmle.Extraction.CSharp.Populators
             attributeLookup = new Lazy<Func<SyntaxNode, AttributeData?>>(() =>
                 {
                     var dict = new Dictionary<SyntaxNode, AttributeData?>();
-                    foreach (var attributeData in cx.Compilation.Assembly.GetAttributes().Concat(cx.Compilation.Assembly.Modules.SelectMany(m => m.GetAttributes())))
+                    foreach (var attributeData in cx.Compilation.Assembly.GetAttributes().Concat(cx.Compilation.Assembly.Modules.SelectMany(m => m.GetAttributes())).Where(attributeData => attributeData.ApplicationSyntaxReference?.GetSyntax() is SyntaxNode syntax))
                     {
-                        if (attributeData.ApplicationSyntaxReference?.GetSyntax() is SyntaxNode syntax)
-                            dict.Add(syntax, attributeData);
+                        var syntax = attributeData.ApplicationSyntaxReference?.GetSyntax() as SyntaxNode;
+                        dict.Add(syntax, attributeData);
                     }
                     return dict.GetValueOrDefault;
                 });


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/codeql/security/code-scanning/4](https://github.com/krishnprakash/codeql/security/code-scanning/4)

To fix the problem, we need to replace the `foreach` loop that implicitly filters its target sequence with a `foreach` loop that explicitly filters the sequence using the `Where` method. This change will make the code more readable and maintainable.

- Replace the `foreach` loop on line 28 with a `foreach` loop that uses the `Where` method to filter the sequence.
- Ensure that the filtering condition `attributeData.ApplicationSyntaxReference?.GetSyntax() is SyntaxNode syntax` is moved to the `Where` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
