### PR TITLE
Potential fix for code scanning alert no. 7: Missed opportunity to use Select

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Context.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Context.cs
@@ -496,9 +496,8 @@ namespace Semmle.Extraction.CSharp
                 return param;
             }
 
-            foreach (var sr in param.DeclaringSyntaxReferences)
+            foreach (var syntax in param.DeclaringSyntaxReferences.Select(sr => sr.GetSyntax()))
             {
-                var syntax = sr.GetSyntax();
                 if (lambdaParameterCache.TryGetValue(syntax, out var cached) &&
                     SymbolEqualityComparer.Default.Equals(param, cached))
                 {


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/codeql/security/code-scanning/7](https://github.com/krishnprakash/codeql/security/code-scanning/7)

To fix the problem, we will replace the `foreach` loop with a LINQ `Select` method. This will transform the sequence of `param.DeclaringSyntaxReferences` to a sequence of `SyntaxNode` objects using the `GetSyntax` method. We will then iterate over this transformed sequence.

- Replace the `foreach` loop with a `Select` method to map `sr` to `sr.GetSyntax()`.
- Iterate over the transformed sequence using a `foreach` loop.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
