### PR TITLE
Potential fix for code scanning alert no. 9: Local scope variable shadows member

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Field.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Field.cs
@@ -107,10 +107,10 @@ namespace Semmle.Extraction.CSharp.Entities
         private Expression AddInitializerAssignment(TextWriter trapFile, ExpressionSyntax initializer, Location loc,
             string? constValue, ref int child)
         {
-            var type = Symbol.GetAnnotatedType();
-            var simpleAssignExpr = new Expression(new ExpressionInfo(Context, type, loc, ExprKind.SIMPLE_ASSIGN, this, child++, isCompilerGenerated: true, constValue));
+            var annotatedType = Symbol.GetAnnotatedType();
+            var simpleAssignExpr = new Expression(new ExpressionInfo(Context, annotatedType, loc, ExprKind.SIMPLE_ASSIGN, this, child++, isCompilerGenerated: true, constValue));
             Expression.CreateFromNode(new ExpressionNodeInfo(Context, initializer, simpleAssignExpr, 0));
-            var access = new Expression(new ExpressionInfo(Context, type, Location, ExprKind.FIELD_ACCESS, simpleAssignExpr, 1, isCompilerGenerated: true, constValue));
+            var access = new Expression(new ExpressionInfo(Context, annotatedType, Location, ExprKind.FIELD_ACCESS, simpleAssignExpr, 1, isCompilerGenerated: true, constValue));
             trapFile.expr_access(access, this);
             return access;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/codeql/security/code-scanning/9](https://github.com/krishnprakash/codeql/security/code-scanning/9)

To fix the problem, we need to rename the local variable `type` on line 110 to avoid shadowing the member variable `type`. This will eliminate the confusion and potential errors caused by the shadowing. The best way to fix this is to choose a new, descriptive name for the local variable that does not conflict with any existing member variables.

In this case, we can rename the local variable `type` to `annotatedType`, which clearly describes its purpose and avoids any naming conflicts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
