### PR TITLE
Potential fix for code scanning alert no. 10: Local scope variable shadows member

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
@@ -44,8 +44,8 @@ namespace Semmle.Extraction.CSharp.Entities
             PopulateNullability(trapFile, Symbol.GetAnnotatedType());
             PopulateRefKind(trapFile, Symbol.RefKind);
 
-            var type = Type;
-            trapFile.properties(this, Symbol.GetName(), ContainingType!, type.TypeRef, Create(Context, Symbol.OriginalDefinition));
+            var propertyType = Type;
+            trapFile.properties(this, Symbol.GetName(), ContainingType!, propertyType.TypeRef, Create(Context, Symbol.OriginalDefinition));
 
             var getter = BodyDeclaringSymbol.GetMethod;
             var setter = BodyDeclaringSymbol.SetMethod;


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/codeql/security/code-scanning/10](https://github.com/krishnprakash/codeql/security/code-scanning/10)

To fix the problem, we need to rename the local variable `type` to avoid shadowing the member variable `type`. This will make the code clearer and prevent any potential confusion or bugs related to variable shadowing. The best way to fix this is to choose a new, descriptive name for the local variable that does not conflict with any existing member variables.

In this case, we can rename the local variable `type` to `propertyType` to clearly indicate its purpose and avoid shadowing the member variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
