### PR TITLE
Potential fix for code scanning alert no. 11: Local scope variable shadows member

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
@@ -22,9 +22,9 @@ namespace Semmle.Extraction.CSharp.Entities
             this.loc = loc;
         }
 
-        private TypeSyntax GetArrayElementType(TypeSyntax type)
+        private TypeSyntax GetArrayElementType(TypeSyntax typeSyntax)
         {
-            switch (type)
+            switch (typeSyntax)
             {
                 case ArrayTypeSyntax ats:
                     return GetArrayElementType(ats.ElementType);
@@ -37,7 +37,7 @@ namespace Semmle.Extraction.CSharp.Entities
                 case PointerTypeSyntax pts:
                     return GetArrayElementType(pts.ElementType);
                 default:
-                    return type;
+                    return typeSyntax;
             }
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/codeql/security/code-scanning/11](https://github.com/krishnprakash/codeql/security/code-scanning/11)

To fix the problem, we need to rename the local variable `type` in the `GetArrayElementType` method to avoid shadowing the member variable `type`. This will make the code clearer and prevent any potential confusion or bugs related to variable shadowing.

- Rename the local variable `type` to `typeSyntax` in the `GetArrayElementType` method.
- Update all references to the local variable within the method to use the new name.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
