### PR TITLE
Potential fix for code scanning alert no. 12: Local scope variable shadows member

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
@@ -118,10 +118,10 @@ namespace Semmle.Extraction.CSharp.Entities
             }
         }
 
-        private void Emit(TextWriter trapFile, Microsoft.CodeAnalysis.Location loc, IEntity parent, Type type)
+        private void Emit(TextWriter trapFile, Microsoft.CodeAnalysis.Location location, IEntity parent, Type type)
         {
             trapFile.type_mention(this, type.TypeRef, parent);
-            trapFile.type_mention_location(this, Context.CreateLocation(loc));
+            trapFile.type_mention_location(this, Context.CreateLocation(location));
         }
 
         public static TypeMention Create(Context cx, TypeSyntax syntax, IEntity parent, Type type, Microsoft.CodeAnalysis.Location? loc = null)


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/codeql/security/code-scanning/12](https://github.com/krishnprakash/codeql/security/code-scanning/12)

To fix the problem, we need to rename the local variable `loc` in the `Emit` method to avoid shadowing the member variable `loc`. This will make the code clearer and prevent any potential confusion or bugs related to variable shadowing.

- In general terms, we should rename the local variable to a name that does not conflict with any member variables.
- Specifically, we will rename the local variable `loc` in the `Emit` method to `location`.
- This change will be made in the file `csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs` on line 121 and any other lines within the `Emit` method that reference the local variable `loc`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
