### PR TITLE
Potential fix for code scanning alert no. 13: Local scope variable shadows member

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
@@ -118,9 +118,9 @@ namespace Semmle.Extraction.CSharp.Entities
             }
         }
 
-        private void Emit(TextWriter trapFile, Microsoft.CodeAnalysis.Location loc, IEntity parent, Type type)
+        private void Emit(TextWriter trapFile, Microsoft.CodeAnalysis.Location loc, IEntity localParent, Type type)
         {
-            trapFile.type_mention(this, type.TypeRef, parent);
+            trapFile.type_mention(this, type.TypeRef, localParent);
             trapFile.type_mention_location(this, Context.CreateLocation(loc));
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/codeql/security/code-scanning/13](https://github.com/krishnprakash/codeql/security/code-scanning/13)

To fix the problem, we need to rename the local variable `parent` in the `Emit` method to avoid shadowing the member variable `parent`. This will make the code clearer and prevent any potential confusion or bugs related to variable shadowing.

- Rename the local variable `parent` in the `Emit` method to a different name, such as `localParent`.
- Update all references to the local variable within the `Emit` method to use the new name.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
