### PR TITLE
Potential fix for code scanning alert no. 14: Local scope variable shadows member

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs
@@ -118,9 +118,9 @@ namespace Semmle.Extraction.CSharp.Entities
             }
         }
 
-        private void Emit(TextWriter trapFile, Microsoft.CodeAnalysis.Location loc, IEntity parent, Type type)
+        private void Emit(TextWriter trapFile, Microsoft.CodeAnalysis.Location loc, IEntity parent, Type localType)
         {
-            trapFile.type_mention(this, type.TypeRef, parent);
+            trapFile.type_mention(this, localType.TypeRef, parent);
             trapFile.type_mention_location(this, Context.CreateLocation(loc));
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/codeql/security/code-scanning/14](https://github.com/krishnprakash/codeql/security/code-scanning/14)

To fix the problem, we need to rename the local variable `type` in the `Emit` method to avoid shadowing the member variable `type`. This will make the code clearer and reduce the risk of errors. The best way to do this is to choose a new name for the local variable that accurately describes its purpose and does not conflict with any existing member variables.

In this case, we can rename the local variable `type` to `localType` in the `Emit` method. This change will be made in the file `csharp/extractor/Semmle.Extraction.CSharp/Entities/TypeMention.cs` on line 121.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
