### PR TITLE
Potential fix for code scanning alert no. 142: Reference equality test on System.Object

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Goto.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Goto.cs
@@ -53,6 +53,6 @@ namespace Semmle.Extraction.CSharp.Entities.Statements
 
         public object? ConstantValue { get; private set; }
 
-        public bool IsDefault => ConstantValue == Switch.DefaultLabel;
+        public bool IsDefault => Equals(ConstantValue, Switch.DefaultLabel);
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/codeql/security/code-scanning/142](https://github.com/krishnprakash/codeql/security/code-scanning/142)

To fix the problem, we need to ensure that the comparison between `ConstantValue` and `Switch.DefaultLabel` is a value comparison rather than a reference comparison. The best way to achieve this is to use the `Equals` method, which performs a value comparison if the `Equals` method is overridden in the class of the objects being compared. This change should be made on line 56 of the file `csharp/extractor/Semmle.Extraction.CSharp/Entities/Statements/Goto.cs`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
