### PR TITLE
Potential fix for code scanning alert no. 288: Missing enum case in switch

### DIFF
--- a/swift/extractor/translators/DeclTranslator.cpp
+++ b/swift/extractor/translators/DeclTranslator.cpp
@@ -222,6 +222,12 @@ codeql::Accessor DeclTranslator::translateAccessorDecl(const swift::AccessorDecl
     case swift::AccessorKind::Init:
       entry.is_init = true;
       break;
+    case swift::AccessorKind::Borrow:
+      break;
+    case swift::AccessorKind::Mutate:
+      break;
+    case swift::AccessorKind::Last:
+      break;
   }
   fillFunction(decl, entry);
   return entry;


### PR DESCRIPTION
Potential fix for [https://github.com/krishnprakash/codeql/security/code-scanning/288](https://github.com/krishnprakash/codeql/security/code-scanning/288)

To fix this without changing existing functionality, make the `switch` exhaustive by adding missing enum cases (`Borrow`, `Mutate`, `Last`) and handling them as no-ops (`break;`) for now.

Best single fix in `swift/extractor/translators/DeclTranslator.cpp`:
- In `DeclTranslator::translateAccessorDecl`, within the existing `switch (decl.getAccessorKind())`, add:
  - `case swift::AccessorKind::Borrow: break;`
  - `case swift::AccessorKind::Mutate: break;`
  - `case swift::AccessorKind::Last: break;`
- Keep existing behavior unchanged for already handled cases.
- No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
